### PR TITLE
Add customizable audio preferences and add-task chime

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,25 @@
             <button class="todo-form__submit" type="submit">Add</button>
           </div>
         </form>
+        <section class="audio-settings" aria-label="Sound preferences">
+          <h2 class="audio-settings__title">Sound preferences</h2>
+          <div class="audio-settings__control">
+            <label class="audio-settings__label" for="completion-sound">Completed task</label>
+            <select class="audio-settings__select" id="completion-sound" name="completion-sound">
+              <option value="completion-bright">Bright chime</option>
+              <option value="completion-soft">Gentle bell</option>
+              <option value="completion-retro">Retro ping</option>
+            </select>
+          </div>
+          <div class="audio-settings__control">
+            <label class="audio-settings__label" for="milestone-sound">Milestone cheer</label>
+            <select class="audio-settings__select" id="milestone-sound" name="milestone-sound">
+              <option value="milestone-fanfare">Triumphant fanfare</option>
+              <option value="milestone-rise">Sparkle rise</option>
+              <option value="milestone-celebration">Sunshine celebration</option>
+            </select>
+          </div>
+        </section>
       </header>
 
       <section class="todo-list">

--- a/script.js
+++ b/script.js
@@ -1,4 +1,23 @@
 const storageKey = "todo-app-tasks";
+const completionStorageKey = "todo-app-completion-stats";
+const audioPreferenceStorageKey = "todo-app-audio-preferences";
+
+const completionSoundIds = [
+  "completion-bright",
+  "completion-soft",
+  "completion-retro",
+];
+
+const milestoneSoundIds = [
+  "milestone-fanfare",
+  "milestone-rise",
+  "milestone-celebration",
+];
+
+const DEFAULT_AUDIO_PREFERENCES = {
+  completionSound: completionSoundIds[0],
+  milestoneSound: milestoneSoundIds[0],
+};
 
 function generateId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -13,10 +32,17 @@ const count = document.getElementById("todo-count");
 const clearCompletedButton = document.getElementById("clear-completed");
 const filterButtons = Array.from(document.querySelectorAll(".filter-button"));
 const itemTemplate = document.getElementById("todo-item-template");
+const completionSoundSelect = document.getElementById("completion-sound");
+const milestoneSoundSelect = document.getElementById("milestone-sound");
 
 let tasks = loadTasks();
 let activeFilter = "all";
+let totalCompletedTasks = loadCompletionCount();
+let audioPreferences = loadAudioPreferences();
 
+const soundEffects = createSoundEffects(() => audioPreferences);
+
+initializeAudioPreferenceControls();
 render();
 
 form.addEventListener("submit", (event) => {
@@ -36,6 +62,7 @@ form.addEventListener("submit", (event) => {
   };
 
   tasks = [newTask, ...tasks];
+  soundEffects.playAddSound();
   input.value = "";
   saveTasks();
   render();
@@ -93,7 +120,94 @@ function saveTasks() {
   localStorage.setItem(storageKey, JSON.stringify(tasks));
 }
 
+function normalizeAudioPreferences(preferences = {}) {
+  const completionSound =
+    preferences && completionSoundIds.includes(preferences.completionSound)
+      ? preferences.completionSound
+      : DEFAULT_AUDIO_PREFERENCES.completionSound;
+  const milestoneSound =
+    preferences && milestoneSoundIds.includes(preferences.milestoneSound)
+      ? preferences.milestoneSound
+      : DEFAULT_AUDIO_PREFERENCES.milestoneSound;
+  return { completionSound, milestoneSound };
+}
+
+function loadAudioPreferences() {
+  try {
+    const raw = localStorage.getItem(audioPreferenceStorageKey);
+    if (!raw) {
+      return { ...DEFAULT_AUDIO_PREFERENCES };
+    }
+    const parsed = JSON.parse(raw);
+    return normalizeAudioPreferences(parsed);
+  } catch (error) {
+    console.error("Failed to load audio preferences", error);
+    return { ...DEFAULT_AUDIO_PREFERENCES };
+  }
+}
+
+function saveAudioPreferences() {
+  audioPreferences = normalizeAudioPreferences(audioPreferences);
+  try {
+    localStorage.setItem(
+      audioPreferenceStorageKey,
+      JSON.stringify(audioPreferences)
+    );
+  } catch (error) {
+    console.error("Failed to save audio preferences", error);
+  }
+}
+
+function updateAudioPreference(key, value) {
+  const validIds =
+    key === "completionSound"
+      ? completionSoundIds
+      : key === "milestoneSound"
+      ? milestoneSoundIds
+      : [];
+
+  if (!validIds.includes(value)) {
+    return false;
+  }
+
+  audioPreferences = normalizeAudioPreferences({
+    ...audioPreferences,
+    [key]: value,
+  });
+  saveAudioPreferences();
+  return true;
+}
+
+function initializeAudioPreferenceControls() {
+  if (completionSoundSelect) {
+    completionSoundSelect.value = audioPreferences.completionSound;
+    completionSoundSelect.addEventListener("change", () => {
+      const selected = completionSoundSelect.value;
+      if (!updateAudioPreference("completionSound", selected)) {
+        completionSoundSelect.value = audioPreferences.completionSound;
+        return;
+      }
+      soundEffects.playSoundById(selected);
+    });
+  }
+
+  if (milestoneSoundSelect) {
+    milestoneSoundSelect.value = audioPreferences.milestoneSound;
+    milestoneSoundSelect.addEventListener("change", () => {
+      const selected = milestoneSoundSelect.value;
+      if (!updateAudioPreference("milestoneSound", selected)) {
+        milestoneSoundSelect.value = audioPreferences.milestoneSound;
+        return;
+      }
+      soundEffects.playSoundById(selected);
+    });
+  }
+}
+
 function toggleTaskCompletion(id, completed) {
+  const existingTask = tasks.find((task) => task.id === id);
+  const wasCompleted = existingTask ? existingTask.completed : false;
+
   tasks = tasks.map((task) =>
     task.id === id
       ? {
@@ -102,6 +216,10 @@ function toggleTaskCompletion(id, completed) {
         }
       : task
   );
+
+  if (!wasCompleted && completed) {
+    handleTaskCompleted();
+  }
   saveTasks();
   render();
 }
@@ -164,4 +282,183 @@ function render() {
   const hasCompleted = tasks.some((task) => task.completed);
   clearCompletedButton.disabled = !hasCompleted;
   clearCompletedButton.classList.toggle("clear-completed--hidden", !hasCompleted);
+}
+
+function loadCompletionCount() {
+  try {
+    const raw = localStorage.getItem(completionStorageKey);
+    if (!raw) return 0;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "number") {
+      return parsed;
+    }
+    if (parsed && typeof parsed.totalCompleted === "number") {
+      return parsed.totalCompleted;
+    }
+    return 0;
+  } catch (error) {
+    console.error("Failed to load completion stats", error);
+    return 0;
+  }
+}
+
+function saveCompletionCount() {
+  localStorage.setItem(
+    completionStorageKey,
+    JSON.stringify({ totalCompleted: totalCompletedTasks })
+  );
+}
+
+function handleTaskCompleted() {
+  totalCompletedTasks += 1;
+  saveCompletionCount();
+  soundEffects.playCompletionSound();
+  if (totalCompletedTasks > 0 && totalCompletedTasks % 5 === 0) {
+    setTimeout(() => {
+      soundEffects.playMilestoneSound();
+    }, 180);
+  }
+}
+
+function createSoundEffects(getPreferences) {
+  const resolvePreferences =
+    typeof getPreferences === "function" ? getPreferences : () => DEFAULT_AUDIO_PREFERENCES;
+
+  const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+  if (typeof AudioContextClass !== "function") {
+    return {
+      playCompletionSound() {},
+      playMilestoneSound() {},
+      playAddSound() {},
+      playSoundById() {
+        return false;
+      },
+    };
+  }
+
+  const context = new AudioContextClass();
+  const masterGain = context.createGain();
+  masterGain.gain.value = 0.22;
+  masterGain.connect(context.destination);
+
+  const soundLibrary = {
+    "completion-bright": [
+      { frequency: 660, duration: 0.16, type: "sine", volume: 0.6 },
+      { frequency: 990, duration: 0.22, type: "triangle", volume: 0.55 },
+    ],
+    "completion-soft": [
+      { frequency: 523.25, duration: 0.24, type: "sine", volume: 0.45 },
+      { frequency: 659.25, duration: 0.18, type: "sine", volume: 0.4 },
+    ],
+    "completion-retro": [
+      { frequency: 783.99, duration: 0.12, type: "square", volume: 0.5 },
+      { frequency: 932.33, duration: 0.12, type: "square", volume: 0.45 },
+      { frequency: 1174.66, duration: 0.14, type: "square", volume: 0.4 },
+    ],
+    "milestone-fanfare": [
+      { frequency: 523.25, duration: 0.22, type: "square", volume: 0.7 },
+      { frequency: 659.25, duration: 0.22, type: "square", volume: 0.68 },
+      { frequency: 783.99, duration: 0.26, type: "sawtooth", volume: 0.65 },
+      { frequency: 1046.5, duration: 0.32, type: "triangle", volume: 0.68 },
+    ],
+    "milestone-rise": [
+      { frequency: 392, duration: 0.18, type: "triangle", volume: 0.58 },
+      { frequency: 523.25, duration: 0.18, type: "triangle", volume: 0.62 },
+      { frequency: 659.25, duration: 0.2, type: "sine", volume: 0.66 },
+      { frequency: 880, duration: 0.28, type: "sine", volume: 0.64 },
+    ],
+    "milestone-celebration": [
+      { frequency: 523.25, duration: 0.18, type: "triangle", volume: 0.6 },
+      { frequency: 659.25, duration: 0.18, type: "triangle", volume: 0.6 },
+      { frequency: 587.33, duration: 0.2, type: "triangle", volume: 0.58 },
+      { frequency: 880, duration: 0.32, type: "sine", volume: 0.68 },
+    ],
+    "task-add-soft": [
+      { frequency: 392, duration: 0.12, type: "sine", volume: 0.3 },
+      { frequency: 523.25, duration: 0.16, type: "triangle", volume: 0.28 },
+    ],
+  };
+
+  function ensureContext() {
+    if (context.state === "suspended") {
+      return context.resume().catch(() => {});
+    }
+    return Promise.resolve();
+  }
+
+  function playNotes(notes) {
+    if (!Array.isArray(notes) || notes.length === 0) {
+      return false;
+    }
+    ensureContext().then(() => {
+      let startTime = context.currentTime + 0.05;
+      notes.forEach((note) => {
+        const { frequency, duration, type, volume } = {
+          frequency: 440,
+          duration: 0.2,
+          type: "sine",
+          volume: 0.5,
+          ...note,
+        };
+        const oscillator = context.createOscillator();
+        oscillator.type = type;
+        oscillator.frequency.setValueAtTime(frequency, startTime);
+
+        const gainNode = context.createGain();
+        const effectiveVolume = Math.max(0.0001, Math.min(volume, 1));
+        gainNode.gain.setValueAtTime(0.0001, startTime);
+        gainNode.gain.linearRampToValueAtTime(
+          effectiveVolume,
+          startTime + Math.min(0.04, duration / 2)
+        );
+        gainNode.gain.exponentialRampToValueAtTime(0.0001, startTime + duration);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(masterGain);
+
+        oscillator.start(startTime);
+        oscillator.stop(startTime + duration + 0.05);
+
+        startTime += duration * 0.85;
+      });
+    });
+    return true;
+  }
+
+  function playSound(soundId) {
+    const notes = soundLibrary[soundId];
+    if (!notes) {
+      return false;
+    }
+    return playNotes(notes);
+  }
+
+  function getNormalizedPreferences() {
+    const raw = resolvePreferences();
+    if (!raw || typeof raw !== "object") {
+      return { ...DEFAULT_AUDIO_PREFERENCES };
+    }
+    return normalizeAudioPreferences(raw);
+  }
+
+  return {
+    playCompletionSound() {
+      const { completionSound } = getNormalizedPreferences();
+      if (!playSound(completionSound)) {
+        playSound(DEFAULT_AUDIO_PREFERENCES.completionSound);
+      }
+    },
+    playMilestoneSound() {
+      const { milestoneSound } = getNormalizedPreferences();
+      if (!playSound(milestoneSound)) {
+        playSound(DEFAULT_AUDIO_PREFERENCES.milestoneSound);
+      }
+    },
+    playAddSound() {
+      playSound("task-add-soft");
+    },
+    playSoundById(soundId) {
+      return playSound(soundId);
+    },
+  };
 }

--- a/style.css
+++ b/style.css
@@ -34,6 +34,59 @@ body {
   margin-bottom: 24px;
 }
 
+.audio-settings {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+}
+
+.audio-settings__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.audio-settings__control {
+  display: grid;
+  gap: 6px;
+}
+
+.audio-settings__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(26, 26, 26, 0.75);
+}
+
+.audio-settings__select {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  background: rgba(255, 255, 255, 0.9);
+  color: #1a1a1a;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.audio-settings__select:focus {
+  border-color: #5b21b6;
+  box-shadow: 0 0 0 3px rgba(91, 33, 182, 0.2);
+  outline: none;
+}
+
+@media (min-width: 640px) {
+  .audio-settings {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: end;
+  }
+
+  .audio-settings__title {
+    grid-column: 1 / -1;
+  }
+}
+
 .todo-form__controls {
   display: grid;
   grid-template-columns: 1fr auto;


### PR DESCRIPTION
## Summary
- add a sound preferences panel so users can pick completion and milestone cheers
- persist the chosen audio styles and feed them into a shared synthesizer-backed sound engine
- play a subtle confirmation tone when new tasks are added

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ced32a26208321894073d12fad7b71