### PR TITLE
Add customizable sound preferences for todo completions

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,21 @@
           </button>
         </footer>
       </section>
+
+      <section class="sound-settings" aria-labelledby="sound-settings-title">
+        <h2 id="sound-settings-title" class="sound-settings__title">Sound preferences</h2>
+        <div class="sound-settings__controls">
+          <label class="sound-settings__field" for="completion-sound">
+            <span class="sound-settings__label">Completed task sound</span>
+            <select id="completion-sound" class="sound-settings__select"></select>
+          </label>
+          <label class="sound-settings__field" for="milestone-sound">
+            <span class="sound-settings__label">5 tasks milestone sound</span>
+            <select id="milestone-sound" class="sound-settings__select"></select>
+          </label>
+        </div>
+        <p class="sound-settings__hint">Sounds play when you finish tasks. Choose “Mute” to disable.</p>
+      </section>
     </main>
 
     <template id="todo-item-template">

--- a/style.css
+++ b/style.css
@@ -199,6 +199,63 @@ body {
   pointer-events: none;
 }
 
+.sound-settings {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  display: grid;
+  gap: 16px;
+}
+
+.sound-settings__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #312e81;
+}
+
+.sound-settings__controls {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 640px) {
+  .sound-settings__controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.sound-settings__field {
+  display: grid;
+  gap: 8px;
+}
+
+.sound-settings__label {
+  font-weight: 600;
+  color: rgba(26, 26, 26, 0.75);
+}
+
+.sound-settings__select {
+  appearance: none;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sound-settings__select:focus {
+  border-color: #5b21b6;
+  box-shadow: 0 0 0 3px rgba(91, 33, 182, 0.2);
+  outline: none;
+}
+
+.sound-settings__hint {
+  font-size: 0.85rem;
+  color: rgba(26, 26, 26, 0.6);
+}
+
 @media (max-width: 480px) {
   .app {
     padding: 24px 20px;


### PR DESCRIPTION
## Summary
- add a sound settings panel that lets users choose completion and milestone effects
- persist sound preferences and update the Web Audio player to use multiple presets or mute
- style the new controls to match the existing design

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cfe0c824e483219cdcf422167505c5