### PR TITLE
Add configurable settings dialog with theme options

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,20 @@
   <body>
     <main class="app">
       <header class="app__header">
-        <h1>Todo List</h1>
+        <div class="app__topbar">
+          <h1>Todo List</h1>
+          <button
+            id="open-settings"
+            class="settings-button"
+            type="button"
+            aria-haspopup="dialog"
+            aria-controls="settings-dialog"
+            aria-expanded="false"
+          >
+            <span class="settings-button__icon" aria-hidden="true">⚙️</span>
+            <span class="settings-button__label">Settings</span>
+          </button>
+        </div>
         <form id="todo-form" class="todo-form" autocomplete="off">
           <label class="todo-form__label" for="todo-input">Add a new task</label>
           <div class="todo-form__controls">
@@ -43,22 +56,64 @@
           </button>
         </footer>
       </section>
-
-      <section class="sound-settings" aria-labelledby="sound-settings-title">
-        <h2 id="sound-settings-title" class="sound-settings__title">Sound preferences</h2>
-        <div class="sound-settings__controls">
-          <label class="sound-settings__field" for="completion-sound">
-            <span class="sound-settings__label">Completed task sound</span>
-            <select id="completion-sound" class="sound-settings__select"></select>
-          </label>
-          <label class="sound-settings__field" for="milestone-sound">
-            <span class="sound-settings__label">5 tasks milestone sound</span>
-            <select id="milestone-sound" class="sound-settings__select"></select>
-          </label>
-        </div>
-        <p class="sound-settings__hint">Sounds play when you finish tasks. Choose “Mute” to disable.</p>
-      </section>
     </main>
+
+    <dialog id="settings-dialog" class="settings-dialog" aria-labelledby="settings-dialog-title">
+      <form method="dialog" class="settings-dialog__form">
+        <header class="settings-dialog__header">
+          <h2 id="settings-dialog-title" class="settings-dialog__title">Settings</h2>
+          <button
+            id="close-settings"
+            class="settings-dialog__close"
+            type="button"
+            aria-label="Close settings"
+          >
+            ×
+          </button>
+        </header>
+
+        <section class="settings-section" aria-labelledby="sound-settings-title">
+          <div class="settings-section__header">
+            <h3 id="sound-settings-title" class="settings-section__title">Sound preferences</h3>
+            <p class="settings-section__description">
+              Pick a tune for your completed tasks or milestone celebrations.
+            </p>
+          </div>
+          <div class="settings-grid">
+            <label class="settings-field" for="completion-sound">
+              <span class="settings-field__label">Completed task sound</span>
+              <select id="completion-sound" class="settings-field__control"></select>
+            </label>
+            <label class="settings-field" for="milestone-sound">
+              <span class="settings-field__label">5 tasks milestone sound</span>
+              <select id="milestone-sound" class="settings-field__control"></select>
+            </label>
+          </div>
+          <p class="settings-section__hint">
+            The chosen sound will play instantly so you can preview it. Choose “Mute” to disable.
+          </p>
+        </section>
+
+        <section class="settings-section" aria-labelledby="theme-settings-title">
+          <div class="settings-section__header">
+            <h3 id="theme-settings-title" class="settings-section__title">Appearance</h3>
+            <p class="settings-section__description">
+              Give your task list a fresh vibe by switching the colors.
+            </p>
+          </div>
+          <div
+            id="theme-options"
+            class="theme-options"
+            role="radiogroup"
+            aria-labelledby="theme-settings-title"
+          ></div>
+        </section>
+
+        <footer class="settings-dialog__actions">
+          <button class="settings-dialog__action" value="cancel" type="submit">Close</button>
+        </footer>
+      </form>
+    </dialog>
 
     <template id="todo-item-template">
       <li class="todo-item">

--- a/script.js
+++ b/script.js
@@ -1,11 +1,14 @@
 const storageKey = "todo-app-tasks";
 const completionStorageKey = "todo-app-completion-stats";
 const soundPreferenceStorageKey = "todo-app-sound-preferences";
+const themePreferenceStorageKey = "todo-app-theme-preference";
 
 const defaultSoundPreferences = {
   completion: "chime",
   milestone: "celebration",
 };
+
+const defaultThemeKey = "lavender";
 
 const soundPresets = {
   completion: {
@@ -71,6 +74,104 @@ const soundPresets = {
   },
 };
 
+const themePresets = {
+  lavender: {
+    label: "Lavender dusk",
+    description: "Dreamy purples with a rosy skyline.",
+    properties: {
+      "background-gradient": "radial-gradient(circle at top, #8ec5fc, #e0c3fc)",
+      "surface-color": "rgba(255, 255, 255, 0.85)",
+      "surface-border": "rgba(0, 0, 0, 0.08)",
+      "surface-border-soft": "rgba(0, 0, 0, 0.05)",
+      "surface-shadow": "rgba(0, 0, 0, 0.15)",
+      "surface-elevated": "rgba(255, 255, 255, 0.85)",
+      "surface-elevated-shadow": "rgba(0, 0, 0, 0.08)",
+      "text-color": "#1a1a1a",
+      "muted-text-color": "rgba(26, 26, 26, 0.6)",
+      "heading-color": "#312e81",
+      "accent-gradient": "linear-gradient(135deg, #6366f1, #8b5cf6)",
+      "accent-color": "#6366f1",
+      "accent-color-strong": "#8b5cf6",
+      "accent-contrast-text": "#ffffff",
+      "accent-pill-background": "rgba(99, 102, 241, 0.1)",
+      "accent-pill-text": "#4338ca",
+      "accent-focus-border": "#5b21b6",
+      "accent-focus-ring": "rgba(91, 33, 182, 0.2)",
+      "accent-shadow": "rgba(99, 102, 241, 0.3)",
+      "dialog-backdrop": "rgba(17, 24, 39, 0.35)",
+      "button-surface": "rgba(255, 255, 255, 0.7)",
+    },
+    preview: {
+      gradient: "linear-gradient(135deg, #8ec5fc, #e0c3fc)",
+      accent: "linear-gradient(135deg, #6366f1, #8b5cf6)",
+    },
+  },
+  aurora: {
+    label: "Aurora breeze",
+    description: "Fresh teals and sunshine accents.",
+    properties: {
+      "background-gradient": "radial-gradient(circle at top, #a1ffce, #faffd1)",
+      "surface-color": "rgba(255, 255, 255, 0.82)",
+      "surface-border": "rgba(13, 148, 136, 0.18)",
+      "surface-border-soft": "rgba(13, 148, 136, 0.1)",
+      "surface-shadow": "rgba(15, 118, 110, 0.18)",
+      "surface-elevated": "rgba(255, 255, 255, 0.9)",
+      "surface-elevated-shadow": "rgba(15, 118, 110, 0.12)",
+      "text-color": "#064e3b",
+      "muted-text-color": "rgba(6, 78, 59, 0.65)",
+      "heading-color": "#047857",
+      "accent-gradient": "linear-gradient(135deg, #1fb6ff, #39f3bb)",
+      "accent-color": "#0ea5e9",
+      "accent-color-strong": "#14b8a6",
+      "accent-contrast-text": "#f0fdfa",
+      "accent-pill-background": "rgba(20, 184, 166, 0.16)",
+      "accent-pill-text": "#0f766e",
+      "accent-focus-border": "#0d9488",
+      "accent-focus-ring": "rgba(13, 148, 136, 0.28)",
+      "accent-shadow": "rgba(14, 165, 233, 0.28)",
+      "dialog-backdrop": "rgba(14, 116, 144, 0.35)",
+      "button-surface": "rgba(255, 255, 255, 0.78)",
+    },
+    preview: {
+      gradient: "linear-gradient(135deg, #a1ffce, #faffd1)",
+      accent: "linear-gradient(135deg, #1fb6ff, #39f3bb)",
+    },
+  },
+  midnight: {
+    label: "Midnight neon",
+    description: "Moody blues with electric highlights.",
+    properties: {
+      "background-gradient": "radial-gradient(circle at top, #1a2a6c, #0f172a 55%, #000428 90%)",
+      "surface-color": "rgba(15, 23, 42, 0.92)",
+      "surface-border": "rgba(148, 163, 184, 0.18)",
+      "surface-border-soft": "rgba(148, 163, 184, 0.12)",
+      "surface-shadow": "rgba(2, 6, 23, 0.65)",
+      "surface-elevated": "rgba(17, 24, 39, 0.95)",
+      "surface-elevated-shadow": "rgba(15, 23, 42, 0.5)",
+      "text-color": "#f1f5f9",
+      "muted-text-color": "rgba(226, 232, 240, 0.72)",
+      "heading-color": "#c7d2fe",
+      "accent-gradient": "linear-gradient(135deg, #6366f1, #22d3ee)",
+      "accent-color": "#818cf8",
+      "accent-color-strong": "#22d3ee",
+      "accent-contrast-text": "#ffffff",
+      "accent-pill-background": "rgba(99, 102, 241, 0.25)",
+      "accent-pill-text": "#c7d2fe",
+      "accent-focus-border": "#22d3ee",
+      "accent-focus-ring": "rgba(34, 211, 238, 0.35)",
+      "accent-shadow": "rgba(129, 140, 248, 0.35)",
+      "dialog-backdrop": "rgba(15, 23, 42, 0.6)",
+      "button-surface": "rgba(17, 24, 39, 0.75)",
+    },
+    preview: {
+      gradient: "linear-gradient(135deg, #1a2a6c, #111827)",
+      accent: "linear-gradient(135deg, #6366f1, #22d3ee)",
+    },
+  },
+};
+
+let currentTheme = applyTheme(loadThemePreference());
+
 function generateId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
@@ -86,6 +187,12 @@ const filterButtons = Array.from(document.querySelectorAll(".filter-button"));
 const itemTemplate = document.getElementById("todo-item-template");
 const completionSoundSelect = document.getElementById("completion-sound");
 const milestoneSoundSelect = document.getElementById("milestone-sound");
+const settingsButton = document.getElementById("open-settings");
+const settingsDialog = document.getElementById("settings-dialog");
+const closeSettingsButton = document.getElementById("close-settings");
+const themeOptionsContainer = document.getElementById("theme-options");
+
+const themeOptionElements = new Map();
 
 let tasks = loadTasks();
 let activeFilter = "all";
@@ -94,6 +201,8 @@ let totalCompletedTasks = loadCompletionCount();
 let soundPreferences = loadSoundPreferences();
 const soundEffects = createSoundEffects(soundPreferences);
 
+setupSettingsDialog();
+setupThemeControls();
 setupSoundControls();
 
 render();
@@ -370,6 +479,229 @@ function setupSoundControls() {
       }
     });
   });
+}
+
+function setupThemeControls() {
+  if (!themeOptionsContainer) {
+    return;
+  }
+
+  themeOptionElements.clear();
+  themeOptionsContainer.innerHTML = "";
+
+  const fragment = document.createDocumentFragment();
+
+  Object.entries(themePresets).forEach(([value, config]) => {
+    const option = document.createElement("label");
+    option.className = "theme-option";
+    if (value === currentTheme) {
+      option.classList.add("theme-option--active");
+    }
+
+    const input = document.createElement("input");
+    input.type = "radio";
+    input.name = "theme";
+    input.value = value;
+    input.className = "theme-option__radio";
+    input.checked = value === currentTheme;
+
+    const preview = document.createElement("span");
+    preview.className = "theme-option__preview";
+    if (config.preview && typeof config.preview === "object") {
+      if (config.preview.gradient) {
+        preview.style.setProperty("--preview-gradient", config.preview.gradient);
+      }
+      if (config.preview.accent) {
+        preview.style.setProperty("--preview-accent", config.preview.accent);
+      }
+    }
+
+    const text = document.createElement("span");
+    text.className = "theme-option__text";
+
+    const name = document.createElement("span");
+    name.className = "theme-option__name";
+    name.textContent = config.label;
+
+    const description = document.createElement("span");
+    description.className = "theme-option__description";
+    description.textContent = config.description;
+
+    text.append(name, description);
+    option.append(input, preview, text);
+
+    themeOptionElements.set(value, option);
+    fragment.append(option);
+  });
+
+  themeOptionsContainer.append(fragment);
+
+  if (!themeOptionsContainer.dataset.initialized) {
+    themeOptionsContainer.addEventListener("change", handleThemeOptionChange);
+    themeOptionsContainer.dataset.initialized = "true";
+  }
+
+  updateThemeOptionSelection();
+}
+
+function handleThemeOptionChange(event) {
+  const target = event.target;
+  if (!target || !target.matches("input[name='theme']")) {
+    return;
+  }
+  setThemePreference(target.value);
+}
+
+function setThemePreference(themeKey) {
+  const validatedTheme = getValidThemePreset(themeKey);
+  if (validatedTheme === currentTheme) {
+    updateThemeOptionSelection();
+    return;
+  }
+
+  currentTheme = applyTheme(validatedTheme);
+  saveThemePreference(currentTheme);
+  updateThemeOptionSelection();
+}
+
+function updateThemeOptionSelection() {
+  themeOptionElements.forEach((element, value) => {
+    const input = element.querySelector(".theme-option__radio");
+    const isActive = value === currentTheme;
+    element.classList.toggle("theme-option--active", isActive);
+    if (input) {
+      input.checked = isActive;
+    }
+  });
+}
+
+function setupSettingsDialog() {
+  if (!settingsDialog || !settingsButton) {
+    return;
+  }
+
+  settingsButton.addEventListener("click", () => {
+    openSettingsDialog();
+  });
+
+  if (closeSettingsButton) {
+    closeSettingsButton.addEventListener("click", () => {
+      closeSettingsDialog();
+    });
+  }
+
+  settingsDialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    closeSettingsDialog();
+  });
+
+  settingsDialog.addEventListener("click", (event) => {
+    if (event.target === settingsDialog) {
+      closeSettingsDialog();
+    }
+  });
+
+  settingsDialog.addEventListener("close", () => {
+    setSettingsButtonExpanded(false);
+  });
+}
+
+function openSettingsDialog() {
+  if (!settingsDialog) {
+    return;
+  }
+
+  if (typeof settingsDialog.showModal === "function") {
+    if (!settingsDialog.open) {
+      settingsDialog.showModal();
+    }
+  } else {
+    settingsDialog.setAttribute("open", "open");
+  }
+
+  setSettingsButtonExpanded(true);
+
+  requestAnimationFrame(() => {
+    updateThemeOptionSelection();
+    const firstInteractive = settingsDialog.querySelector(
+      "button, input, select, textarea, [href], [tabindex]:not([tabindex='-1'])"
+    );
+    if (firstInteractive && typeof firstInteractive.focus === "function") {
+      firstInteractive.focus();
+    }
+  });
+}
+
+function closeSettingsDialog() {
+  if (!settingsDialog) {
+    return;
+  }
+
+  if (typeof settingsDialog.close === "function") {
+    if (settingsDialog.open) {
+      settingsDialog.close();
+    }
+  } else {
+    settingsDialog.removeAttribute("open");
+  }
+
+  setSettingsButtonExpanded(false);
+}
+
+function loadThemePreference() {
+  try {
+    const stored = localStorage.getItem(themePreferenceStorageKey);
+    if (!stored) {
+      return defaultThemeKey;
+    }
+    return getValidThemePreset(stored);
+  } catch (error) {
+    console.error("Failed to load theme preference", error);
+    return defaultThemeKey;
+  }
+}
+
+function saveThemePreference(themeKey) {
+  try {
+    localStorage.setItem(themePreferenceStorageKey, getValidThemePreset(themeKey));
+  } catch (error) {
+    console.error("Failed to save theme preference", error);
+  }
+}
+
+function getValidThemePreset(themeKey) {
+  if (themeKey && typeof themeKey === "string" && themePresets[themeKey]) {
+    return themeKey;
+  }
+  return defaultThemeKey;
+}
+
+function applyTheme(themeKey) {
+  const validatedTheme = getValidThemePreset(themeKey);
+  const root = document.documentElement;
+
+  const baseTheme = themePresets[defaultThemeKey];
+  if (baseTheme && baseTheme.properties) {
+    Object.entries(baseTheme.properties).forEach(([variable, value]) => {
+      root.style.setProperty(`--${variable}`, value);
+    });
+  }
+
+  const theme = themePresets[validatedTheme];
+  if (theme && theme.properties) {
+    Object.entries(theme.properties).forEach(([variable, value]) => {
+      root.style.setProperty(`--${variable}`, value);
+    });
+  }
+
+  return validatedTheme;
+}
+
+function setSettingsButtonExpanded(isExpanded) {
+  if (!settingsButton) {
+    return;
+  }
+  settingsButton.setAttribute("aria-expanded", String(Boolean(isExpanded)));
 }
 
 function handleTaskCompleted() {

--- a/style.css
+++ b/style.css
@@ -1,8 +1,28 @@
 :root {
   color-scheme: light dark;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: radial-gradient(circle at top, #8ec5fc, #e0c3fc);
   min-height: 100vh;
+  --background-gradient: radial-gradient(circle at top, #8ec5fc, #e0c3fc);
+  --surface-color: rgba(255, 255, 255, 0.85);
+  --surface-border: rgba(0, 0, 0, 0.08);
+  --surface-border-soft: rgba(0, 0, 0, 0.05);
+  --surface-shadow: rgba(0, 0, 0, 0.15);
+  --surface-elevated: rgba(255, 255, 255, 0.85);
+  --surface-elevated-shadow: rgba(0, 0, 0, 0.08);
+  --text-color: #1a1a1a;
+  --muted-text-color: rgba(26, 26, 26, 0.6);
+  --heading-color: #312e81;
+  --accent-gradient: linear-gradient(135deg, #6366f1, #8b5cf6);
+  --accent-color: #6366f1;
+  --accent-color-strong: #8b5cf6;
+  --accent-contrast-text: #ffffff;
+  --accent-pill-background: rgba(99, 102, 241, 0.1);
+  --accent-pill-text: #4338ca;
+  --accent-focus-border: #5b21b6;
+  --accent-focus-ring: rgba(91, 33, 182, 0.2);
+  --accent-shadow: rgba(99, 102, 241, 0.3);
+  --dialog-backdrop: rgba(17, 24, 39, 0.35);
+  --button-surface: rgba(255, 255, 255, 0.7);
 }
 
 * {
@@ -15,14 +35,18 @@ body {
   min-height: 100vh;
   display: grid;
   place-items: center;
-  background: transparent;
-  color: #1a1a1a;
+  background: var(--background-gradient);
+  color: var(--text-color);
+}
+
+::selection {
+  background: var(--accent-focus-ring);
 }
 
 .app {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--surface-color);
   border-radius: 16px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 20px 40px var(--surface-shadow);
   width: min(640px, 90vw);
   padding: 32px;
   backdrop-filter: blur(12px);
@@ -34,6 +58,44 @@ body {
   margin-bottom: 24px;
 }
 
+.app__topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.settings-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 8px 16px;
+  background: var(--button-surface);
+  color: var(--accent-pill-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.settings-button:hover,
+.settings-button:focus {
+  transform: translateY(-1px);
+  background: var(--accent-pill-background);
+  box-shadow: 0 10px 18px var(--accent-shadow);
+  outline: none;
+}
+
+.settings-button:focus-visible {
+  box-shadow: 0 0 0 3px var(--accent-focus-ring);
+}
+
+.settings-button__icon {
+  font-size: 1.05rem;
+}
+
 .todo-form__controls {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -42,15 +104,15 @@ body {
 
 .todo-form__input {
   padding: 12px 16px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--surface-border);
   border-radius: 999px;
   font-size: 1rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .todo-form__input:focus {
-  border-color: #5b21b6;
-  box-shadow: 0 0 0 3px rgba(91, 33, 182, 0.2);
+  border-color: var(--accent-focus-border);
+  box-shadow: 0 0 0 3px var(--accent-focus-ring);
   outline: none;
 }
 
@@ -58,8 +120,8 @@ body {
   padding: 12px 20px;
   border: none;
   border-radius: 999px;
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  color: white;
+  background: var(--accent-gradient);
+  color: var(--accent-contrast-text);
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -68,7 +130,7 @@ body {
 .todo-form__submit:hover,
 .todo-form__submit:focus {
   transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(99, 102, 241, 0.3);
+  box-shadow: 0 8px 16px var(--accent-shadow);
 }
 
 .todo-list {
@@ -93,16 +155,22 @@ body {
   border: none;
   border-radius: 999px;
   padding: 8px 16px;
-  background: rgba(99, 102, 241, 0.1);
-  color: #4338ca;
+  background: var(--accent-pill-background);
+  color: var(--accent-pill-text);
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-button:hover,
+.filter-button:focus {
+  box-shadow: 0 6px 12px var(--accent-shadow);
+  outline: none;
 }
 
 .filter-button[aria-pressed="true"] {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  color: white;
+  background: var(--accent-gradient);
+  color: var(--accent-contrast-text);
 }
 
 .todo-items {
@@ -117,16 +185,16 @@ body {
   align-items: center;
   padding: 12px 16px;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(0, 0, 0, 0.05);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+  background: var(--surface-elevated);
+  border: 1px solid var(--surface-border-soft);
+  box-shadow: 0 10px 20px var(--surface-elevated-shadow);
 }
 
 .todo-item--empty {
   justify-content: center;
   padding-block: 24px;
   font-style: italic;
-  color: rgba(26, 26, 26, 0.6);
+  color: var(--muted-text-color);
 }
 
 .todo-item__label {
@@ -139,7 +207,7 @@ body {
 .todo-item__checkbox {
   width: 20px;
   height: 20px;
-  accent-color: #6366f1;
+  accent-color: var(--accent-color);
 }
 
 .todo-item__text {
@@ -148,13 +216,13 @@ body {
 
 .todo-item.completed .todo-item__text {
   text-decoration: line-through;
-  color: rgba(26, 26, 26, 0.5);
+  color: var(--muted-text-color);
 }
 
 .todo-item__delete {
   border: none;
   background: transparent;
-  color: rgba(26, 26, 26, 0.6);
+  color: var(--muted-text-color);
   font-size: 24px;
   line-height: 1;
   cursor: pointer;
@@ -165,8 +233,8 @@ body {
 
 .todo-item__delete:hover,
 .todo-item__delete:focus {
-  background: rgba(99, 102, 241, 0.1);
-  color: #4c1d95;
+  background: var(--accent-pill-background);
+  color: var(--accent-color);
 }
 
 .todo-list__footer {
@@ -174,7 +242,7 @@ body {
   justify-content: space-between;
   align-items: center;
   font-size: 0.9rem;
-  color: rgba(26, 26, 26, 0.7);
+  color: var(--muted-text-color);
 }
 
 .clear-completed {
@@ -199,61 +267,215 @@ body {
   pointer-events: none;
 }
 
-.sound-settings {
-  margin-top: 32px;
-  padding-top: 24px;
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
+.settings-dialog {
+  border: none;
+  border-radius: 18px;
+  padding: 0;
+  max-width: min(560px, 92vw);
+  width: 100%;
+  background: var(--surface-color);
+  color: var(--text-color);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(18px);
+}
+
+.settings-dialog::backdrop {
+  background: var(--dialog-backdrop);
+  backdrop-filter: blur(4px);
+}
+
+.settings-dialog__form {
   display: grid;
+  gap: 28px;
+  padding: 32px 32px 28px;
+}
+
+.settings-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 16px;
 }
 
-.sound-settings__title {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #312e81;
+.settings-dialog__title {
+  font-size: 1.4rem;
+  font-weight: 700;
 }
 
-.sound-settings__controls {
+.settings-dialog__close {
+  border: none;
+  background: transparent;
+  font-size: 1.6rem;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 999px;
+  cursor: pointer;
+  color: var(--muted-text-color);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.settings-dialog__close:hover,
+.settings-dialog__close:focus {
+  background: var(--accent-pill-background);
+  color: var(--accent-color);
+  outline: none;
+}
+
+.settings-section {
+  display: grid;
+  gap: 18px;
+}
+
+.settings-section__header {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-section__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--heading-color);
+}
+
+.settings-section__description {
+  font-size: 0.9rem;
+  color: var(--muted-text-color);
+}
+
+.settings-grid {
   display: grid;
   gap: 16px;
 }
 
 @media (min-width: 640px) {
-  .sound-settings__controls {
+  .settings-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-.sound-settings__field {
+.settings-field {
   display: grid;
   gap: 8px;
 }
 
-.sound-settings__label {
+.settings-field__label {
   font-weight: 600;
   color: rgba(26, 26, 26, 0.75);
 }
 
-.sound-settings__select {
+.settings-field__control {
   appearance: none;
   padding: 10px 14px;
   border-radius: 999px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--surface-border);
   background: rgba(255, 255, 255, 0.9);
   font-size: 0.95rem;
   line-height: 1.4;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.sound-settings__select:focus {
-  border-color: #5b21b6;
-  box-shadow: 0 0 0 3px rgba(91, 33, 182, 0.2);
+.settings-field__control:focus {
+  border-color: var(--accent-focus-border);
+  box-shadow: 0 0 0 3px var(--accent-focus-ring);
   outline: none;
 }
 
-.sound-settings__hint {
+.settings-section__hint {
   font-size: 0.85rem;
-  color: rgba(26, 26, 26, 0.6);
+  color: var(--muted-text-color);
+}
+
+.theme-options {
+  display: grid;
+  gap: 14px;
+}
+
+.theme-option {
+  display: grid;
+  grid-template-columns: auto 56px 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--surface-border);
+  background: rgba(255, 255, 255, 0.78);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.theme-option:hover,
+.theme-option:focus-within {
+  border-color: var(--accent-color);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+}
+
+.theme-option--active {
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--accent-focus-ring);
+}
+
+.theme-option__radio {
+  accent-color: var(--accent-color);
+  width: 18px;
+  height: 18px;
+}
+
+.theme-option__preview {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: var(--preview-gradient);
+  position: relative;
+  overflow: hidden;
+}
+
+.theme-option__preview::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 10px;
+  background: var(--preview-accent);
+  opacity: 0.85;
+}
+
+.theme-option__text {
+  display: grid;
+  gap: 4px;
+}
+
+.theme-option__name {
+  font-weight: 600;
+}
+
+.theme-option__description {
+  font-size: 0.85rem;
+  color: var(--muted-text-color);
+}
+
+.theme-option--active .theme-option__name {
+  color: var(--accent-color);
+}
+
+.settings-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.settings-dialog__action {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  background: var(--accent-gradient);
+  color: var(--accent-contrast-text);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 16px var(--accent-shadow);
+}
+
+.settings-dialog__action:hover,
+.settings-dialog__action:focus {
+  transform: translateY(-1px);
+  outline: none;
 }
 
 @media (max-width: 480px) {
@@ -267,5 +489,14 @@ body {
 
   .todo-form__submit {
     width: 100%;
+  }
+
+  .settings-dialog__form {
+    padding: 24px 20px 20px;
+    gap: 24px;
+  }
+
+  .theme-option {
+    grid-template-columns: auto 48px 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated settings dialog accessed from the header
- move sound controls into the dialog and keep instant preview on change
- introduce persistent theme presets so users can switch the app colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfe402411083218acc118b81122df4